### PR TITLE
更新wlogout锁定操作为使用 swaylock或hyprlock（原配置该按钮似乎没有效果）

### DIFF
--- a/dotfiles/.config/wlogout/layout
+++ b/dotfiles/.config/wlogout/layout
@@ -1,6 +1,6 @@
 {
     "label" : "lock",
-    "action" : "loginctl lock-session",
+    "action" : "swaylock || hyprlock",
     "text" : "Lock",
     "keybind" : "l"
 }


### PR DESCRIPTION
不知道是不是我的问题，总之wlogout的电源菜单中的lock似乎没有效果，于是参照waybar配置中的lock键修改了配置，经本人测试有效