### PR TITLE
Fixed an issue where quicksave.sh failed to create snapshots correctly.

### DIFF
--- a/dotfiles/.config/scripts/quicksave.sh
+++ b/dotfiles/.config/scripts/quicksave.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-snapper -c root create --description "quicksave"  --cleanup-algorithm number
-snapper -c root cleanup number
-snapper -c home create --description "quicksave" --cleanup-algorithm number
-snapper -c home cleanup number
-notify-send "Quicksaved."
+# 提权但是使用here-doc，不显示代码内容
+if pkexec bash << 'EOF'; then
+    snapper -c root create --description "quicksave" --cleanup-algorithm number
+    snapper -c root cleanup number
+    snapper -c home create --description "quicksave" --cleanup-algorithm number
+    snapper -c home cleanup number
+EOF
+    notify-send "Quicksaved: Success"
+else
+    notify-send -u critical "Quicksaved: Failed!"
+fi


### PR DESCRIPTION
The `snapper` portion of the `quicksave.sh` script is granted root privileges to ensure that snapshots are created correctly and to provide notifications about the creation results.