### PR TITLE
[FEAT] 增加xhost临时授权脚本以运行需要提权的x11程序

### DIFF
--- a/dotfiles/.local/bin/rootrunx
+++ b/dotfiles/.local/bin/rootrunx
@@ -1,0 +1,4 @@
+#!/bin/bash
+xhost +SI:localuser:root
+trap 'xhost -SI:localuser:root' EXIT
+"$@"


### PR DESCRIPTION
在运行某些需要提权的x11程序（如easytier-gui,ventoy）在提权后会因为root用户无xhost权限而无法初始化xwayland窗口，该脚本可以通过临时授予root用户xhost权限的方式解决这一问题，可以在命令行或.desktop文件使用。