### PR TITLE
Fix documentation typos and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="pictures/shorinarch.png" alt="SHORiNのARCH Logo" width="500" />
-  <br><br> 
-  
+  <br><br>
+
   <a href="https://space.bilibili.com/9202840"><img src="https://img.shields.io/badge/Bilibili-关注我-pink?logo=bilibili" alt="Bilibili"></a>
   <img src="https://img.shields.io/badge/Platform-Arch_Linux-blue?logo=arch-linux" alt="Platform">
   <a href="https://github.com/SHORiN-KiWATA/Shorin-ArchLinux-Guide/blob/main/LICENSE"><img src="https://img.shields.io/github/license/SHORiN-KiWATA/Shorin-ArchLinux-Guide" alt="License"></a>
@@ -9,48 +9,48 @@
 
 ## 项目简介
 
-这是我作为纯小白尝试Linux后选择日用Arch Linux的实践经历，总结出了我心中入门桌面端Linux的最佳路径。你可以沿着我走过的路上手，应该会轻松很多。
+这是我作为纯小白尝试 Linux 后选择日用 Arch Linux 的实践经历，总结出了我心中入门桌面端 Linux 的最佳路径。你可以沿着我走过的路上手，应该会轻松很多。
 
 
 <details><summary>[展开/收起] 内容包括</summary>
 
-- 选择Linux发行版和排雷避坑
-- 安装Linux的必做通用准备工作
-- Linux Mint、CachyOS等易用发行版的安装和使用教程（包含Win双系统配置）
-- Arch Linux安装详解（含手动安装、脚本安装、btrfs文件系统特化配置、Win双系统配置等等）
-- Arch安装桌面环境前的所有准备工作（显卡驱动、固件、音视频服务、休眠、蓝牙、软件源和商城等等）
+- 选择 Linux 发行版和排雷避坑
+- 安装 Linux 的必做通用准备工作
+- Linux Mint、CachyOS 等易用发行版的安装和使用教程（包含Win 双系统配置）
+- Arch Linux 安装详解（含手动安装、脚本安装、Btrfs 文件系统特化配置、Win 双系统配置等等）
+- Arch 安装桌面环境前的所有准备工作（显卡驱动、固件、音视频服务、休眠、蓝牙、软件源和商城等等）
 - 详细的快照配置方法、系统维护口诀
-- 常用桌面环境介绍、安装、配置和美化方法（GNOME、Plasma、Niri、Hyprland等等）
+- 常用桌面环境介绍、安装、配置和美化方法（GNOME、Plasma、Niri、Hyprland 等等）
 - 中文输入法、软件安装等常见需求
-- Linux玩游戏详解
-- 常用虚拟机安装和使用方法（VMware、VirtualBox、DistroBox等）
-- KVM虚拟机安装和配置详解（安装虚拟机Win11、文件共享、远程桌面、冷切换和热切换显卡直通、lookingglass、虚拟机性能优化和伪装等等）
+- Linux 玩游戏详解
+- 常用虚拟机安装和使用方法（VMware、VirtualBox、DistroBox 等）
+- KVM 虚拟机安装和配置详解（安装虚拟机Win11、文件共享、远程桌面、冷切换和热切换显卡直通、Looking Glass、虚拟机性能优化和伪装等等）
 - 实用小技巧和常见问题
-- 干净地删除Linux系统
+- 干净地删除 Linux 系统
 - 其他
 
 </details>
 
 
-## [点击开始阅读](https://github.com/SHORiN-KiWATA/ShorinArchExperience-ArchlinuxGuide/wiki)
+## [点击开始阅读](https://github.com/SHORiN-KiWATA/Shorin-ArchLinux-Guide/wiki)
 
-- [**ShorinWiki**](https://github.com/SHORiN-KiWATA/ShorinArchExperience-ArchlinuxGuide/wiki)
+- [**ShorinWiki**](https://github.com/SHORiN-KiWATA/Shorin-ArchLinux-Guide/wiki)
 
-- [**便利脚本：一键配置Arch Linux**](https://github.com/SHORiN-KiWATA/ShorinArchExperience-ArchlinuxGuide/wiki/%E4%B8%80%E9%94%AE%E9%85%8D%E7%BD%AE%E6%A1%8C%E9%9D%A2%E7%8E%AF%E5%A2%83)
+- [**便利脚本：一键配置Arch Linux**](https://github.com/SHORiN-KiWATA/Shorin-ArchLinux-Guide/wiki/%E4%B8%80%E9%94%AE%E9%85%8D%E7%BD%AE%E6%A1%8C%E9%9D%A2%E7%8E%AF%E5%A2%83)
 
-    我的一键配置脚本。用于为安装好的Arch Linux和Arch衍生发行版进行所有必要的基础配置，还可以使用我的配置文件搭建桌面环境。
+    我的一键配置脚本。用于为安装好的Arch Linux 和 Arch 衍生发行版进行所有必要的基础配置，还可以使用我的配置文件搭建桌面环境。
 
 ## 电子榨菜
 
-这里有一些我制作的视频，欢迎关注我的bilibili频道。
+这里有一些我制作的视频，欢迎关注我的Bilibili 频道。
 
-- 挑战Linux玩游戏
+- 挑战 Linux 玩游戏
 
-    [「Linux游戏指南」一次挑战与一场斗争](https://www.bilibili.com/video/BV1zyttzPEmp/?share_source=copy_web)
+    [「Linux 游戏指南」一次挑战与一场斗争](https://www.bilibili.com/video/BV1zyttzPEmp/?share_source=copy_web)
 
-- 纯小白在禁止使用终端的情况下体验Linux
+- 纯小白在禁止使用终端的情况下体验 Linux
 
-    [「女友体验Linux」全程禁用命令行，颠覆刻板印象，纯小白也能轻松上手！](https://www.bilibili.com/video/BV1YvenzUEFf/?share_source=copy_web)
+    [「女友体验 Linux」全程禁用命令行，颠覆刻板印象，纯小白也能轻松上手！](https://www.bilibili.com/video/BV1YvenzUEFf/?share_source=copy_web)
 
 
 ## 鸣谢
@@ -59,15 +59,15 @@
 
 - [Linux Mint](https://linuxmint.com/) 最新手友好的 Linux 发行版，没有之一
 - [Arch Wiki](https://wiki.archlinux.org/title/Main_page) 《圣经》
-- [Arch Linux 简明指南](https://arch.icekylin.online/) 新手友好的Arch Linux 教程
+- [Arch Linux 简明指南](https://arch.icekylin.online/) 新手友好的 Arch Linux 教程
 - [Linux 中国](https://space.bilibili.com/203983793?spm_id_from=333.337.0.0) 中文互联网少有的优质 Linux 内容
 - [Reddit](https://www.reddit.com/) 在这可以找到任何东西
-- [Google Gemini Ai](https://gemini.google.com) 最有人味的强大Ai
+- [Google Gemini AI](https://gemini.google.com) 最有人味的强大 AI
 - [Youtuber@Bog](https://www.youtube.com/@bogxd) 启发我制作视频
 - [Youtuber@michael_tunnell](https://www.youtube.com/@michael_tunnell) 优质 Linux 资讯教程博主
 - [Youtuber@MichaelNROH](https://www.youtube.com/@MichaelNROH) 优质 Linux 资讯教程博主
 - [Youtuber@TheLinuxEXP](https://www.youtube.com/@TheLinuxEXP) 优质 Linux 资讯教程博主
-- [Youtuber@@saneAspect](https://www.youtube.com/@saneAspect) 优质 Hyprland 教程博主
+- [Youtuber@saneAspect](https://www.youtube.com/@saneAspect) 优质 Hyprland 教程博主
 
 ### 项目引用
 

--- a/更新日志.md
+++ b/更新日志.md
@@ -17,11 +17,11 @@ gitee
 
 2025.7.31 更新looking glass使用技巧，包括键鼠捕获
 
-2025.8.1  新增安装前准备
+2025.8.1 新增安装前准备
 
-2025.8.4  新增小黄鸭 Lossless Scaling相关内容
+2025.8.4 新增小黄鸭 Lossless Scaling相关内容
 
-2025.8.5  修复了错误，优化了排版
+2025.8.5 修复了错误，优化了排版
 
 2025.8.12 新增虚拟机性能优化和伪装相关内容
 
@@ -33,11 +33,11 @@ gitee
 
 2025.8.31 新增专业软件替代品一栏
 
-2025.9.2  附录新增vmware相关内容
+2025.9.2 附录新增vmware相关内容
 
-2025.9.6  找到了steam下载时无法正常调用cpu的元凶——btrfs写时复制
+2025.9.6 找到了steam下载时无法正常调用cpu的元凶——btrfs写时复制
 
-2025.9.6  原timeshift移至附录，换用snapper+btrfs assitent
+2025.9.6 原timeshift移至附录，换用snapper+btrfs assistant
 
 2025.9.10 新增KDE桌面安装和美化教程；原zsh内容移至附录，换用fish
 


### PR DESCRIPTION
## Summary
- Fix outdated wiki links and minor Chinese/English spacing issues in README
- Correct small typos in the changelog
- Keep the changes limited to documentation formatting and typo fixes

## Validation
- Reviewed the rendered Markdown-sensitive changes locally
- Ran `git diff --check`
