### PR TITLE
Fix niri screenshot script syntax

### DIFF
--- a/legacy/.config/niri/scripts/screenshot.sh
+++ b/legacy/.config/niri/scripts/screenshot.sh
@@ -59,4 +59,3 @@ else
     # 5. 剪贴板变化后，管道传递给 satty
     wl-paste | satty -f -
 fi
-fi


### PR DESCRIPTION
Remove an extra closing fi in the legacy niri screenshot script so it passes bash syntax validation.\n\nValidation:\n- bash -n legacy/.config/niri/scripts/screenshot.sh\n- git diff --check