### PR TITLE
fix(docs): update niri documentation links

### DIFF
--- a/wiki/archlinux/安装Niri.md
+++ b/wiki/archlinux/安装Niri.md
@@ -87,7 +87,7 @@ sudo pacman -S fish
 
 ## 安装
 
-> [Niri-Getting-Started](https://yalter.github.io/niri/Getting-Started.html)
+> [Niri-Getting-Started](https://github.com/niri-wm/niri/wiki/Getting-Started)
 
 1. 安装
 
@@ -272,7 +272,7 @@ mouse {
 
 ## 重要程序
 
-> [Niri-List-of-Important_Software](https://yalter.github.io/niri/Important-Software.html) | [Niri-XWayland](https://yalter.github.io/niri/Xwayland.html)
+> [Niri-List-of-Important_Software](https://github.com/niri-wm/niri/wiki/Important-Software) | [Niri-XWayland](https://github.com/niri-wm/niri/wiki/Xwayland)
 
 1. 安装
 


### PR DESCRIPTION
## Problem

`wiki/archlinux/安装Niri.md` still points to old Niri documentation pages under `yalter.github.io/niri/*.html`:

- `https://yalter.github.io/niri/Getting-Started.html`
- `https://yalter.github.io/niri/Important-Software.html`
- `https://yalter.github.io/niri/Xwayland.html`

These URLs now return 404.

## Root cause

The Niri documentation moved to the `niri-wm/niri` GitHub Wiki, but these reference links were not updated.

## Fix

Update the three references to the current wiki pages:

- `https://github.com/niri-wm/niri/wiki/Getting-Started`
- `https://github.com/niri-wm/niri/wiki/Important-Software`
- `https://github.com/niri-wm/niri/wiki/Xwayland`

## Tests

- Verified the old URLs return 404.
- Verified the replacement URLs return 200.
- Ran `git diff --check`.
