### PR TITLE
fix(docs): correct unsafe and broken command examples

### DIFF
--- a/wiki/archlinux/issues.md
+++ b/wiki/archlinux/issues.md
@@ -307,10 +307,11 @@ gsettings set org.gnome.desktop.interface color-scheme "prefer-light" && gsettin
 
 ## NetworkManager切换到IWD后端后使用impala联网提示operation aborted
 
-删除 `/etc/NetworkManager/system-connections` 下记忆的 WiFi，重启服务之后即可联网。
+先用 `nmcli connection show` 找到出现问题的 WiFi 连接名称，只删除该连接配置，再重启 NetworkManager。不要清空 `/etc/NetworkManager/system-connections`，该目录还可能保存静态 IP、VPN、网桥等其他连接。
 
 ```bash
-sudo rm -rf /etc/NetworkManager/system-connections/*
+nmcli connection show
+sudo nmcli connection delete "连接名称"
 sudo systemctl restart NetworkManager
 ```
 

--- a/wiki/others/shorinos.md
+++ b/wiki/others/shorinos.md
@@ -131,8 +131,7 @@
         在 `repo-add` 时添加 `--sign --key <密钥 ID >` 选项对生成的数据文件进行签名
 
         ```
-         repo-add --sign --key 8ED9ABE61CDBAABAC4B6A694C9218E60C13B4BA8 shorin-arch.db.tar.zst shorin-contrib-git-r70.ac8
-        0b05-1-any.pkg.tar.zst
+         repo-add --sign --key 8ED9ABE61CDBAABAC4B6A694C9218E60C13B4BA8 shorin-arch.db.tar.zst shorin-contrib-git-r70.ac80b05-1-any.pkg.tar.zst
         ==> 正在将shorin-arch.db.tar.zst提取到临时位置…
         ==> 正在将shorin-arch.files.tar.zst提取到临时位置…
         ==> 正在添加软件包 'shorin-contrib-git-r70.ac80b05-1-any.pkg.tar.zst'


### PR DESCRIPTION
## Problem

Two command examples can cause incorrect behavior when copied from the documentation:

- The NetworkManager troubleshooting command deletes every saved persistent connection, not only the failing Wi-Fi profile.
- A `repo-add` example splits one package filename across two shell commands.

## Root cause

The NetworkManager workaround uses a directory-wide wildcard, and the package filename was accidentally wrapped without a shell continuation character.

## Fix

- List saved connections and delete only the selected connection with `nmcli connection delete`.
- Restore the complete package filename on the `repo-add` command line.

## Tests

- Ran `git diff --check`.
- Confirmed the destructive `/etc/NetworkManager/system-connections/*` deletion is removed.
- Confirmed the package filename matches the subsequent `repo-add` output and remains on one command line.