### PR TITLE
更新 Star History 图表域名

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@
 
 # Star History
 
-<a href="https://star-history.com/#SHORiN-KiWATA/Shorin-ArchLinux-Guide&Date">
+<a href="https://star-history.dera.page/#SHORiN-KiWATA/Shorin-ArchLinux-Guide&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SHORiN-KiWATA/Shorin-ArchLinux-Guide&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SHORiN-KiWATA/Shorin-ArchLinux-Guide&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SHORiN-KiWATA/Shorin-ArchLinux-Guide&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SHORiN-KiWATA/Shorin-ArchLinux-Guide&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SHORiN-KiWATA/Shorin-ArchLinux-Guide&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SHORiN-KiWATA/Shorin-ArchLinux-Guide&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
当前 README 中的 Star History 图表已经失效，原因是 GitHub 星标接口的访问限制。改用 star-history.dera.page 恢复图表显示。